### PR TITLE
Should fix the parse error going to event-stream.

### DIFF
--- a/deployInstructions.js
+++ b/deployInstructions.js
@@ -39,7 +39,24 @@ module.exports = function(archivePath, config) {
         done(err);
       });
 
-      ostream.pipe(stream);
+      // Pipe to event-stream.
+      ostream.pipe(function(data) {
+        var pipe_data = null;
+
+        // Try to parse as JSON.
+        try {
+          pipe_data = JSON.parse(data);
+        } catch(error) {
+          // It isn't JSON so make it JSON.
+          pipe_data = {
+            type: 'stdout',
+            data: data.toString()
+          };
+        }
+
+        // Write out.
+        stream(pipe_data);
+      });
     });
   };
 }


### PR DESCRIPTION
This should fix the parse issue from the container going to `event-stream`

The issue is `event-stream` **only** accepts JSON and the stream is piping plain strings, just try to parse as JSON and if it fails, make it JSON.

I thought this was an issue with `event-stream` and it is not so I've closed my PR to them.

@keyvanfatehi @knownasilya 
